### PR TITLE
Azoteq gesture support

### DIFF
--- a/drivers/sensors/azoteq_iqs5xx.c
+++ b/drivers/sensors/azoteq_iqs5xx.c
@@ -43,9 +43,19 @@
 #define AZOTEQ_IQS5XX_REG_REPORT_RATE_LP1 0x0580
 #define AZOTEQ_IQS5XX_REG_REPORT_RATE_LP2 0x0582
 
+#define AZOTEQ_IQS5XX_REG_SYSTEM_CONFIG_1 0x058F
+
+#define AZOTEQ_IQS5XX_REG_SINGLE_FINGER_GESTURES 0x06B7
+#define AZOTEQ_IQS5XX_REG_MULTI_FINGER_GESTURES 0x06B8
+
 #define AZOTEQ_IQS5XX_REG_ 0x000
 
 #define AZOTEQ_IQS5XX_REG_END_COMMS 0xEEEE
+
+i2c_status_t azoteq_iqs5xx_end_session(void) {
+    const uint8_t END_BYTE = 1; // any data
+    return i2c_writeReg16(AZOTEQ_IQS5XX_ADDRESS, AZOTEQ_IQS5XX_REG_END_COMMS, &END_BYTE, 1, AZOTEQ_IQS5XX_TIMEOUT_MS);
+}
 
 i2c_status_t azoteq_iqs5xx_get_base_data(azoteq_iqs5xx_base_data_t *base_data) {
     //azoteq_iqs5xx_report_rate_t  report_rate  = {0};
@@ -58,11 +68,6 @@ i2c_status_t azoteq_iqs5xx_get_base_data(azoteq_iqs5xx_base_data_t *base_data) {
     // }
     azoteq_iqs5xx_end_session();
     return status;
-}
-
-i2c_status_t azoteq_iqs5xx_end_session(void) {
-    const uint8_t END_BYTE = 1; // any data
-    return i2c_writeReg16(AZOTEQ_IQS5XX_ADDRESS, AZOTEQ_IQS5XX_REG_END_COMMS, &END_BYTE, 1, AZOTEQ_IQS5XX_TIMEOUT_MS);
 }
 
 i2c_status_t azoteq_iqs5xx_get_report_rate(azoteq_iqs5xx_report_rate_t *report_rate, azoteq_charging_modes_t mode, bool END_SESSION) {
@@ -93,4 +98,71 @@ i2c_status_t azoteq_iqs5xx_set_report_rate(uint16_t report_rate_ms, azoteq_charg
         azoteq_iqs5xx_end_session();
     }
     return status;
+}
+
+void azoteq_iqs5xx_set_event_mode(bool enabled) {
+    azoteq_iqs5xx_system_config_1_t config = {0};
+    i2c_status_t                    status = i2c_readReg16(AZOTEQ_IQS5XX_ADDRESS, AZOTEQ_IQS5XX_REG_SYSTEM_CONFIG_1, (uint8_t *)&config, sizeof(azoteq_iqs5xx_system_config_1_t), AZOTEQ_IQS5XX_TIMEOUT_MS);
+    if (status == I2C_STATUS_SUCCESS) {
+        config.event_mode  = true;
+        config.touch_event = true;
+        config.tp_event    = true;
+        status             = i2c_writeReg16(AZOTEQ_IQS5XX_ADDRESS, AZOTEQ_IQS5XX_REG_SYSTEM_CONFIG_1, (uint8_t *)&config, sizeof(azoteq_iqs5xx_system_config_1_t), AZOTEQ_IQS5XX_TIMEOUT_MS);
+    }
+    azoteq_iqs5xx_end_session();
+}
+
+void azoteq_iqs5xx_set_gesture_config(void) {
+    azoteq_iqs5xx_gesture_config_t config = {0};
+    i2c_status_t                 status = i2c_readReg16(AZOTEQ_IQS5XX_ADDRESS, AZOTEQ_IQS5XX_REG_SINGLE_FINGER_GESTURES, (uint8_t *)&config, sizeof(azoteq_iqs5xx_gesture_config_t), AZOTEQ_IQS5XX_TIMEOUT_MS);
+    if (status == I2C_STATUS_SUCCESS) {
+        config.single_finger_gestures.single_tap    = true;
+        config.multi_finger_gestures.two_finger_tap = true;
+        config.multi_finger_gestures.scroll         = true;
+        config.tap_time                             = 500;
+        config.tap_distance                         = 100;
+        config.scroll_initial_distance              = 5;
+        status = i2c_writeReg16(AZOTEQ_IQS5XX_ADDRESS, AZOTEQ_IQS5XX_REG_SINGLE_FINGER_GESTURES, (uint8_t *)&config, sizeof(azoteq_iqs5xx_gesture_config_t), AZOTEQ_IQS5XX_TIMEOUT_MS);
+    }
+    azoteq_iqs5xx_end_session();
+}
+
+void azoteq_iqs5xx_init(void) {
+    i2c_init();
+    azoteq_iqs5xx_set_report_rate(5, ACTIVE, true);
+    azoteq_iqs5xx_set_event_mode(true);
+    azoteq_iqs5xx_set_gesture_config();
+};
+
+report_mouse_t azoteq_iqs5xx_get_report(report_mouse_t mouse_report) {
+    report_mouse_t              temp_report = {0};
+    azoteq_iqs5xx_base_data_t   report_data = {0};
+    i2c_status_t status = azoteq_iqs5xx_get_base_data(&report_data);
+
+    if (status == I2C_STATUS_SUCCESS) {
+        if (report_data.gesture_events_0.single_tap) {
+            temp_report.buttons = pointing_device_handle_buttons(temp_report.buttons, true, POINTING_DEVICE_BUTTON1);
+        }
+        if (report_data.gesture_events_1.two_finger_tap) {
+            temp_report.buttons = pointing_device_handle_buttons(temp_report.buttons, true, POINTING_DEVICE_BUTTON2);
+        }
+        if (report_data.gesture_events_1.scroll) {
+#if defined(MOUSE_EXTENDED_REPORT)
+            temp_report.v = (int16_t) AZOTEQ_IQS5XX_COMBINE_H_L_BYTES(base_data.x.h, base_data.x.l);
+#else
+            temp_report.v = (int8_t) report_data.x.l;
+#endif
+        }
+        else if (report_data.number_of_fingers != 0) {
+#if defined(MOUSE_EXTENDED_REPORT)
+            temp_report.x = (int16_t)AZOTEQ_IQS5XX_COMBINE_H_L_BYTES(base_data.x.h, base_data.x.l);
+            temp_report.y = (int16_t)AZOTEQ_IQS5XX_COMBINE_H_L_BYTES(base_data.y.h, base_data.y.l);
+#else
+            temp_report.x = (int8_t)report_data.x.l;
+            temp_report.y = (int8_t)report_data.y.l;
+#endif
+        }
+    }
+
+    return temp_report;
 }

--- a/drivers/sensors/azoteq_iqs5xx.c
+++ b/drivers/sensors/azoteq_iqs5xx.c
@@ -117,10 +117,12 @@ void azoteq_iqs5xx_set_gesture_config(void) {
     i2c_status_t                 status = i2c_readReg16(AZOTEQ_IQS5XX_ADDRESS, AZOTEQ_IQS5XX_REG_SINGLE_FINGER_GESTURES, (uint8_t *)&config, sizeof(azoteq_iqs5xx_gesture_config_t), AZOTEQ_IQS5XX_TIMEOUT_MS);
     if (status == I2C_STATUS_SUCCESS) {
         config.single_finger_gestures.single_tap    = true;
+        config.single_finger_gestures.press_and_hold= true;
         config.multi_finger_gestures.two_finger_tap = true;
         config.multi_finger_gestures.scroll         = true;
         config.tap_time                             = 500;
-        config.tap_distance                         = 100;
+        config.hold_time                            = 1000;
+        config.tap_distance                         = 10;
         config.scroll_initial_distance              = 5;
         status = i2c_writeReg16(AZOTEQ_IQS5XX_ADDRESS, AZOTEQ_IQS5XX_REG_SINGLE_FINGER_GESTURES, (uint8_t *)&config, sizeof(azoteq_iqs5xx_gesture_config_t), AZOTEQ_IQS5XX_TIMEOUT_MS);
     }
@@ -136,30 +138,30 @@ void azoteq_iqs5xx_init(void) {
 
 report_mouse_t azoteq_iqs5xx_get_report(report_mouse_t mouse_report) {
     report_mouse_t              temp_report = {0};
-    azoteq_iqs5xx_base_data_t   report_data = {0};
-    i2c_status_t status = azoteq_iqs5xx_get_base_data(&report_data);
+    azoteq_iqs5xx_base_data_t   base_data = {0};
+    i2c_status_t status = azoteq_iqs5xx_get_base_data(&base_data);
 
     if (status == I2C_STATUS_SUCCESS) {
-        if (report_data.gesture_events_0.single_tap) {
+        if (base_data.gesture_events_0.single_tap || base_data.gesture_events_0.press_and_hold) {
             temp_report.buttons = pointing_device_handle_buttons(temp_report.buttons, true, POINTING_DEVICE_BUTTON1);
         }
-        if (report_data.gesture_events_1.two_finger_tap) {
+        if (base_data.gesture_events_1.two_finger_tap) {
             temp_report.buttons = pointing_device_handle_buttons(temp_report.buttons, true, POINTING_DEVICE_BUTTON2);
         }
-        if (report_data.gesture_events_1.scroll) {
+        if (base_data.gesture_events_1.scroll) {
 #if defined(MOUSE_EXTENDED_REPORT)
             temp_report.v = (int16_t) AZOTEQ_IQS5XX_COMBINE_H_L_BYTES(base_data.x.h, base_data.x.l);
 #else
-            temp_report.v = (int8_t) report_data.x.l;
+            temp_report.v = (int8_t) base_data.x.l;
 #endif
         }
-        else if (report_data.number_of_fingers != 0) {
+        else if (base_data.number_of_fingers != 0) {
 #if defined(MOUSE_EXTENDED_REPORT)
             temp_report.x = (int16_t)AZOTEQ_IQS5XX_COMBINE_H_L_BYTES(base_data.x.h, base_data.x.l);
             temp_report.y = (int16_t)AZOTEQ_IQS5XX_COMBINE_H_L_BYTES(base_data.y.h, base_data.y.l);
 #else
-            temp_report.x = (int8_t)report_data.x.l;
-            temp_report.y = (int8_t)report_data.y.l;
+            temp_report.x = (int8_t)base_data.x.l;
+            temp_report.y = (int8_t)base_data.y.l;
 #endif
         }
     }

--- a/drivers/sensors/azoteq_iqs5xx.h
+++ b/drivers/sensors/azoteq_iqs5xx.h
@@ -76,25 +76,42 @@ typedef struct __attribute__((packed)) {
 _Static_assert(sizeof(azoteq_iqs5xx_report_data_t) == 5, "azoteq_iqs5xx_report_data_t should be 5 bytes");
 
 typedef struct __attribute__((packed)) {
-    bool event_mode : 1;
-    bool gesture_event : 1;
-    bool tp_event : 1;
-    bool reati_event : 1;
+    bool event_mode     : 1;
+    bool gesture_event  : 1;
+    bool tp_event       : 1;
+    bool reati_event    : 1;
     bool alp_prox_event : 1;
-    bool snap_event : 1;
-    bool touch_event : 1;
-    bool prox_event : 1;
+    bool snap_event     : 1;
+    bool touch_event    : 1;
+    bool prox_event     : 1;
 } azoteq_iqs5xx_system_config_1_t;
 
 typedef struct __attribute__((packed)) {
-    bool suspend : 1;
-    bool reset : 1;
-    int8_t _unused : 6;
+    bool suspend    : 1;
+    bool reset      : 1;
+    int8_t _unused  : 6;
 } azoteq_iqs5xx_system_control_1_t;
 
 typedef struct __attribute__((packed)) {
-    azoteq_iqs5xx_gesture_events_0_t single_finger_gestures;
-    azoteq_iqs5xx_gesture_events_1_t multi_finger_gestures;
+    bool single_tap     : 1;
+    bool press_and_hold : 1;
+    bool swipe_x_minus  : 1;
+    bool swipe_x_plus   : 1;
+    bool swipe_y_minus  : 1;
+    bool swipe_y_plus   : 1;
+    int8_t _unused      : 2;
+} azoteq_iqs5xx_single_finger_gesture_enable_t;
+
+typedef struct __attribute__((packed)) {
+    bool two_finger_tap : 1;
+    bool scroll         : 1;
+    bool zoom           : 1;
+    int8_t _unused      : 5;
+} azoteq_iqs5xx_multi_finger_gesture_enable_t;
+
+typedef struct __attribute__((packed)) {
+    azoteq_iqs5xx_single_finger_gesture_enable_t single_finger_gestures;
+    azoteq_iqs5xx_multi_finger_gesture_enable_t multi_finger_gestures;
     uint16_t tap_time;
     uint16_t tap_distance;
     uint16_t hold_time;

--- a/drivers/sensors/azoteq_iqs5xx.h
+++ b/drivers/sensors/azoteq_iqs5xx.h
@@ -1,4 +1,5 @@
 // Copyright 2023 Dasky (@daskygit)
+// Copyright 2023 George Norton (@george-norton)
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #pragma once

--- a/drivers/sensors/azoteq_iqs5xx.h
+++ b/drivers/sensors/azoteq_iqs5xx.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "i2c_master.h"
+#include "pointing_device.h"
 
 typedef struct __attribute__((packed)) {
     uint8_t h : 8;
@@ -66,12 +67,49 @@ typedef struct __attribute__((packed)) {
 
 _Static_assert(sizeof(azoteq_iqs5xx_base_data_t) == 10, "azoteq_iqs5xx_basic_report_t should be 10 bytes");
 
+typedef struct __attribute__((packed)) {
+    uint8_t                     number_of_fingers;
+    azoteq_iqs5xx_relative_xy_t x;
+    azoteq_iqs5xx_relative_xy_t y;
+} azoteq_iqs5xx_report_data_t;
+
+_Static_assert(sizeof(azoteq_iqs5xx_report_data_t) == 5, "azoteq_iqs5xx_report_data_t should be 5 bytes");
+
+typedef struct __attribute__((packed)) {
+    bool event_mode : 1;
+    bool gesture_event : 1;
+    bool tp_event : 1;
+    bool reati_event : 1;
+    bool alp_prox_event : 1;
+    bool snap_event : 1;
+    bool touch_event : 1;
+    bool prox_event : 1;
+} azoteq_iqs5xx_system_config_1_t;
+
+typedef struct __attribute__((packed)) {
+    bool suspend : 1;
+    bool reset : 1;
+    int8_t _unused : 6;
+} azoteq_iqs5xx_system_control_1_t;
+
+typedef struct __attribute__((packed)) {
+    azoteq_iqs5xx_gesture_events_0_t single_finger_gestures;
+    azoteq_iqs5xx_gesture_events_1_t multi_finger_gestures;
+    uint16_t tap_time;
+    uint16_t tap_distance;
+    uint16_t hold_time;
+    uint16_t swipe_initial_time;
+    uint16_t swipe_initial_distance;
+    uint16_t swipe_consecutive_time;
+    uint16_t swipe_consecutive_distance;
+    uint8_t  swipe_angle;
+    uint16_t scroll_initial_distance;
+    uint8_t  scroll_angle;
+    uint16_t zoom_initial_distance;
+    uint16_t zoom_consecutive_distance;
+} azoteq_iqs5xx_gesture_config_t;
+
 #define AZOTEQ_IQS5XX_COMBINE_H_L_BYTES(h, l) ((h << 8) | l)
 
-i2c_status_t azoteq_iqs5xx_get_base_data(azoteq_iqs5xx_base_data_t *base_data);
-
-i2c_status_t azoteq_iqs5xx_end_session(void);
-
-i2c_status_t azoteq_iqs5xx_get_report_rate(azoteq_iqs5xx_report_rate_t *report_rate, azoteq_charging_modes_t mode, bool END_SESSION);
-
-i2c_status_t azoteq_iqs5xx_set_report_rate(uint16_t report_rate_ms, azoteq_charging_modes_t mode, bool END_SESSION);
+void azoteq_iqs5xx_init(void);
+report_mouse_t azoteq_iqs5xx_get_report(report_mouse_t mouse_report);

--- a/quantum/pointing_device/pointing_device_drivers.c
+++ b/quantum/pointing_device/pointing_device_drivers.c
@@ -95,25 +95,6 @@ const pointing_device_driver_t pointing_device_driver = {
 
 #elif defined(POINTING_DEVICE_DRIVER_azoteq_iqs5xx)
 
-void azoteq_iqs5xx_init(void) {
-    i2c_init();
-}
-
-report_mouse_t azoteq_iqs5xx_get_report(report_mouse_t mouse_report) {
-
-   azoteq_iqs5xx_base_data_t base_data = {0};
-   azoteq_iqs5xx_get_base_data(&base_data);
-
-#if defined(MOUSE_EXTENDED_REPORT)
-    mouse_report.x = (int16_t)AZOTEQ_IQS5XX_COMBINE_H_L_BYTES(base_data.x.h, base_data.x.l);
-    mouse_report.y = (int16_t)AZOTEQ_IQS5XX_COMBINE_H_L_BYTES(base_data.y.h, base_data.y.l);
-#else
-    mouse_report.x = (int8_t)base_data.x.l;
-    mouse_report.y = (int8_t)base_data.y.l;
-#endif
-    return mouse_report;
-}
-
 // clang-format off
 const pointing_device_driver_t pointing_device_driver = {
     .init       = azoteq_iqs5xx_init,


### PR DESCRIPTION
I have rebased my gestures changes on the `azoteq_iqs5xx` branch.
## Description
There are more changes here than I anticipated, it appears that on the `azoteq_iqs5xx` branch the code in `azoteq_iqs5xx.c` wasn't used, instead there was a basic implementation in `pointing_device_drivers.c`. I have fixed this up, but now `azoteq_iqs5xx.h` includes `pointing_device.h` (to get the definition of `report_mouse_t`) which may be undesirable.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
