### PR TITLE
Support get and set CPI in the AZOTEQ_IQS5XX driver.

### DIFF
--- a/drivers/sensors/azoteq_iqs5xx.h
+++ b/drivers/sensors/azoteq_iqs5xx.h
@@ -7,6 +7,14 @@
 #include "i2c_master.h"
 #include "pointing_device.h"
 
+#ifndef AZOTEQ_IQS5XX_WIDTH_MM
+    #define AZOTEQ_IQS5XX_WIDTH_MM 43
+#endif
+
+#ifndef AZOTEQ_IQS5XX_HEIGHT_MM
+    #define AZOTEQ_IQS5XX_HEIGHT_MM 40
+#endif
+
 typedef struct __attribute__((packed)) {
     uint8_t h : 8;
     uint8_t l : 8;
@@ -127,6 +135,11 @@ typedef struct __attribute__((packed)) {
     uint16_t                                     zoom_consecutive_distance;
 } azoteq_iqs5xx_gesture_config_t;
 
+typedef struct __attribute__((packed)) {
+    uint16_t                                     x_resolution;
+    uint16_t                                     y_resolution;
+} azoteq_iqs5xx_resolution_t;
+
 #define AZOTEQ_IQS5XX_COMBINE_H_L_BYTES(h, l) ((h << 8) | l)
 #define AZOTEQ_IQS5XX_SWAP_H_L_BYTES(b) ((uint16_t)(b << 8) | (b >> 8))
 
@@ -148,3 +161,5 @@ i2c_status_t   azoteq_iqs5xx_set_report_rate(uint16_t report_rate_ms, azoteq_cha
 i2c_status_t   azoteq_iqs5xx_set_event_mode(bool enabled, bool end_session);
 i2c_status_t   azoteq_iqs5xx_set_gesture_config(bool end_session);
 i2c_status_t   azoteq_iqs5xx_get_base_data(azoteq_iqs5xx_base_data_t *base_data);
+void           azoteq_iqs5xx_set_cpi(uint16_t cpi);
+uint16_t       azoteq_iqs5xx_get_cpi(void);

--- a/quantum/pointing_device/pointing_device_drivers.c
+++ b/quantum/pointing_device/pointing_device_drivers.c
@@ -179,8 +179,8 @@ report_mouse_t azoteq_iqs5xx_get_report(report_mouse_t mouse_report) {
 const pointing_device_driver_t pointing_device_driver = {
     .init       = azoteq_iqs5xx_init,
     .get_report = azoteq_iqs5xx_get_report,
-    .set_cpi    = NULL,
-    .get_cpi    = NULL
+    .set_cpi    = azoteq_iqs5xx_set_cpi,
+    .get_cpi    = azoteq_iqs5xx_get_cpi
 };
 // clang-format on
 


### PR DESCRIPTION
Implemented `get_cpi` and `set_cpi`.

## Description

Implemented `get_cpi` and `set_cpi` functions. The implementation is based on the cirque, we just adjust the x and y resolution of the sensor. There is no guarantee that you will read back exactly the same CPI value you set as rounding errors may occur. I don't think this is an issue, but we can fix it if you like.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

You can now adjust the cpi for Azoteq trackpads. I found it a bit fast before.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
